### PR TITLE
Auth v2 schema migrations (#37)

### DIFF
--- a/supabase/migrations/20260420000000_remove_phone_auth.sql
+++ b/supabase/migrations/20260420000000_remove_phone_auth.sql
@@ -1,0 +1,16 @@
+-- Auth v2 migration 1/3: drop phone-based auth artifacts from users.
+-- See infrastructure/ACCOUNT_AND_PAIRING.md §6.1 and §6.2.
+-- Issue: izzy-yum/web#37.
+
+-- phone_device_token is migrated into user_devices.push_token by migration 3's
+-- §6.5 backfill (run separately if alpha data ever populated this column).
+ALTER TABLE users DROP COLUMN IF EXISTS phone_device_token;
+
+-- phone / phone_verified never existed in the current schema; IF EXISTS guards
+-- the case where an older branch or cloud environment still has them.
+ALTER TABLE users DROP COLUMN IF EXISTS phone;
+ALTER TABLE users DROP COLUMN IF EXISTS phone_verified;
+
+-- email is already UNIQUE NOT NULL in the core-tables migration; this is a
+-- no-op locally but guarantees the invariant on any environment that drifted.
+ALTER TABLE users ALTER COLUMN email SET NOT NULL;

--- a/supabase/migrations/20260420000001_add_display_name_and_handle.sql
+++ b/supabase/migrations/20260420000001_add_display_name_and_handle.sql
@@ -1,0 +1,13 @@
+-- Auth v2 migration 2/3: add display_name and reserved handle columns to users.
+-- See infrastructure/ACCOUNT_AND_PAIRING.md §2.2, §2.4, §6.3.
+-- Issue: izzy-yum/web#37.
+
+-- DEFAULT exists only to backfill rows created before Auth v2 signup collected
+-- the field; the default is then dropped so new rows must supply display_name.
+ALTER TABLE users
+  ADD COLUMN display_name TEXT NOT NULL DEFAULT 'Hungry Cook';
+ALTER TABLE users ALTER COLUMN display_name DROP DEFAULT;
+
+-- Reserved for future social features (see §2.4). Nullable + UNIQUE so that
+-- multiple NULLs coexist in Postgres while any populated handle stays unique.
+ALTER TABLE users ADD COLUMN handle TEXT UNIQUE;

--- a/supabase/migrations/20260420000002_device_pairing.sql
+++ b/supabase/migrations/20260420000002_device_pairing.sql
@@ -1,0 +1,56 @@
+-- Auth v2 migration 3/3: device pairing + device tables.
+-- See infrastructure/ACCOUNT_AND_PAIRING.md §6.3 and §6.4.
+-- Issue: izzy-yum/web#37.
+
+-- user_devices is created before device_pairing_codes because
+-- device_pairing_codes.consumed_by_device_id has a FK into user_devices(id).
+-- The design doc lists them in the opposite order; that would fail to apply.
+CREATE TABLE user_devices (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    platform TEXT NOT NULL CHECK (platform IN ('ios', 'android', 'web')),
+    device_name TEXT,
+    push_token TEXT,
+    first_paired_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    revoked_at TIMESTAMPTZ
+);
+CREATE INDEX idx_user_devices_user
+    ON user_devices (user_id)
+    WHERE revoked_at IS NULL;
+CREATE INDEX idx_user_devices_push_token
+    ON user_devices (push_token)
+    WHERE revoked_at IS NULL AND push_token IS NOT NULL;
+
+CREATE TABLE device_pairing_codes (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    opaque_token TEXT NOT NULL UNIQUE,
+    display_code TEXT NOT NULL,
+    display_code_attempts INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ NOT NULL,
+    consumed_at TIMESTAMPTZ,
+    consumed_by_device_id UUID REFERENCES user_devices(id)
+);
+CREATE INDEX idx_pairing_active
+    ON device_pairing_codes (user_id)
+    WHERE consumed_at IS NULL;
+CREATE INDEX idx_pairing_token ON device_pairing_codes (opaque_token);
+
+-- RLS: user_devices is client-visible for SELECT + UPDATE (revoke) scoped to self.
+ALTER TABLE user_devices ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "users see their own devices"
+    ON user_devices FOR SELECT
+    USING (user_id = auth.uid());
+CREATE POLICY "users revoke their own devices"
+    ON user_devices FOR UPDATE
+    USING (user_id = auth.uid())
+    WITH CHECK (user_id = auth.uid());
+
+-- RLS: device_pairing_codes has no direct client access; pairing is mediated by
+-- edge functions (web#45) using the service role, which bypasses RLS.
+ALTER TABLE device_pairing_codes ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "no direct client access"
+    ON device_pairing_codes FOR ALL
+    USING (false);


### PR DESCRIPTION
## Summary
- Adds three migrations implementing [`ACCOUNT_AND_PAIRING.md` §6](https://github.com/izzy-yum/infrastructure/blob/main/ACCOUNT_AND_PAIRING.md#6-schema-diff): drop phone-based auth, add `display_name` + reserved `handle`, introduce `user_devices` + `device_pairing_codes` with RLS.
- Fixes a forward-reference in the design doc: within `device_pairing.sql`, `user_devices` is created before `device_pairing_codes` (the latter has an FK into the former).

Closes #37.

## Migrations
- `20260420000000_remove_phone_auth.sql` — drops `phone_device_token`, `phone`, `phone_verified` (IF EXISTS); reaffirms `email NOT NULL`.
- `20260420000001_add_display_name_and_handle.sql` — adds `display_name` with a backfill default then drops the default; adds nullable `handle TEXT UNIQUE` (reserved, see §2.4).
- `20260420000002_device_pairing.sql` — creates `user_devices` and `device_pairing_codes` with indexes and RLS policies per §6.3 / §6.4.

## Test plan
- [x] `supabase db reset` locally applies all migrations clean (phone/phone_verified IF-EXISTS NOTICEs are expected).
- [x] `supabase db diff` local reports "No schema changes found" — no drift.
- [x] `pg_class.relrowsecurity = t` for both new tables locally.
- [x] `SET ROLE anon` cannot see rows in `device_pairing_codes` (policy `USING (false)`) nor in `user_devices` (policy scoped to `auth.uid()`).
- [x] No seed or production data referenced `phone_device_token`; alpha hasn't shipped.
- [x] `supabase db push` against Supabase Cloud (`oogpnrrsmpklafdrvvkg`) applied cleanly; `\d users` on cloud confirms `display_name NOT NULL` + `handle UNIQUE`, both new tables present, no `phone_*` columns.

## Notes for reviewers
- `user_devices` RLS uses `auth.uid()`, which becomes meaningful once #38/#41 wire Supabase Auth into the app. The policy is correct now and functional once those land.
- This PR only touches schema. iOS CoreData bump for the shopping_list tables is unaffected by this change (no shopping_list schema touched here).
- `supabase db diff --linked` surfaces pre-existing cloud drift unrelated to this PR (Complete Plate tables use `gen_random_uuid()` on cloud vs. `uuid_generate_v4()` in migrations; `pg_net` extension present on cloud). Worth a follow-up but out of scope for #37.