### PR TITLE
Enable Apple OAuth + scratch smoke-test page (#38)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Standalone Node CJS scripts, not part of the Next.js build.
+    "scripts/**",
   ]),
 ]);
 

--- a/scripts/generate-apple-client-secret.js
+++ b/scripts/generate-apple-client-secret.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Generate the Apple OAuth client_secret JWT that Supabase's Dashboard requires
+// in the "Secret Key (for OAuth)" field for the Apple provider.
+//
+// Apple's client_secret is an ES256-signed JWT (not the raw .p8). Max lifetime
+// is ~6 months, so this runs on a rotation schedule. See
+// infrastructure/RUNBOOK_OAUTH_SETUP.md for the end-to-end procedure.
+//
+// Usage:
+//   APPLE_TEAM_ID=VWFHD2N44D \
+//   APPLE_KEY_ID=RY499TP287 \
+//   APPLE_CLIENT_ID=com.izzyyum.app.web-signin \
+//   APPLE_P8_PATH=/path/to/AuthKey_RY499TP287.p8 \
+//   node scripts/generate-apple-client-secret.js
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const required = ['APPLE_TEAM_ID', 'APPLE_KEY_ID', 'APPLE_CLIENT_ID', 'APPLE_P8_PATH'];
+const missing = required.filter((k) => !process.env[k]);
+if (missing.length) {
+  console.error(`Missing env vars: ${missing.join(', ')}`);
+  process.exit(1);
+}
+
+const privateKey = fs.readFileSync(path.resolve(process.env.APPLE_P8_PATH), 'utf8');
+
+const now = Math.floor(Date.now() / 1000);
+const exp = now + 15552000; // 180 days — under Apple's ~182.5-day cap.
+
+const header = { alg: 'ES256', kid: process.env.APPLE_KEY_ID, typ: 'JWT' };
+const payload = {
+  iss: process.env.APPLE_TEAM_ID,
+  iat: now,
+  exp,
+  aud: 'https://appleid.apple.com',
+  sub: process.env.APPLE_CLIENT_ID,
+};
+
+const b64url = (obj) =>
+  Buffer.from(JSON.stringify(obj))
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+
+const signingInput = `${b64url(header)}.${b64url(payload)}`;
+const signer = crypto.createSign('SHA256');
+signer.update(signingInput);
+signer.end();
+// Apple requires JOSE's IEEE P1363 signature format (r||s), not DER.
+const signature = signer.sign({ key: privateKey, dsaEncoding: 'ieee-p1363' });
+const sigB64 = signature
+  .toString('base64')
+  .replace(/=/g, '')
+  .replace(/\+/g, '-')
+  .replace(/\//g, '_');
+
+console.error(`# JWT expires: ${new Date(exp * 1000).toISOString()}  (rotate before then)`);
+console.log(`${signingInput}.${sigB64}`);

--- a/src/app/auth/test/page.tsx
+++ b/src/app/auth/test/page.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+// Scratch smoke-test page for Auth v2 OAuth providers. Lets us click through
+// each provider end-to-end and verify that a row appears in auth.users +
+// auth.identities. Not linked from anywhere in the main app nav.
+// Delete once the real signup UI ships (web#41).
+
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabase'
+import type { Session, User } from '@supabase/supabase-js'
+
+export default function AuthTestPage() {
+  const [session, setSession] = useState<Session | null>(null)
+  const [user, setUser] = useState<User | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(data.session)
+      setUser(data.session?.user ?? null)
+    })
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, s) => {
+      setSession(s)
+      setUser(s?.user ?? null)
+    })
+    return () => sub.subscription.unsubscribe()
+  }, [])
+
+  const signInWithApple = async () => {
+    setError(null)
+    setLoading(true)
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'apple',
+      options: { redirectTo: `${window.location.origin}/auth/test` },
+    })
+    if (error) {
+      setError(error.message)
+      setLoading(false)
+    }
+  }
+
+  const signOut = async () => {
+    await supabase.auth.signOut()
+    setSession(null)
+    setUser(null)
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl p-8 font-sans">
+      <h1 className="mb-6 text-2xl font-semibold">Auth v2 OAuth smoke test</h1>
+
+      <section className="mb-8 rounded-lg border border-gray-200 p-4">
+        <h2 className="mb-2 text-lg font-medium">Status</h2>
+        {session ? (
+          <>
+            <p className="text-sm text-green-700">Signed in.</p>
+            <dl className="mt-3 space-y-1 text-sm">
+              <div className="flex gap-2">
+                <dt className="font-medium">User ID:</dt>
+                <dd className="font-mono text-xs">{user?.id}</dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="font-medium">Email:</dt>
+                <dd>{user?.email ?? <em>(none)</em>}</dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="font-medium">Provider:</dt>
+                <dd>{user?.app_metadata?.provider ?? '—'}</dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="font-medium">Providers linked:</dt>
+                <dd>{(user?.app_metadata?.providers as string[] | undefined)?.join(', ') ?? '—'}</dd>
+              </div>
+            </dl>
+            <details className="mt-3">
+              <summary className="cursor-pointer text-sm text-gray-600">Raw user JSON</summary>
+              <pre className="mt-2 overflow-x-auto rounded bg-gray-50 p-3 text-xs">
+                {JSON.stringify(user, null, 2)}
+              </pre>
+            </details>
+          </>
+        ) : (
+          <p className="text-sm text-gray-600">Not signed in.</p>
+        )}
+      </section>
+
+      <section className="space-y-3">
+        <button
+          type="button"
+          onClick={signInWithApple}
+          disabled={loading}
+          className="w-full rounded-md bg-black px-4 py-3 text-white hover:bg-gray-800 disabled:opacity-50"
+        >
+          {loading ? 'Redirecting…' : 'Continue with Apple'}
+        </button>
+
+        {session && (
+          <button
+            type="button"
+            onClick={signOut}
+            className="w-full rounded-md border border-gray-300 px-4 py-3 text-gray-700 hover:bg-gray-50"
+          >
+            Sign out
+          </button>
+        )}
+
+        {error && (
+          <p className="rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">{error}</p>
+        )}
+      </section>
+
+      <p className="mt-8 text-xs text-gray-500">
+        This page is a temporary smoke-test surface for <code>web#38</code>. It will be deleted
+        once the real signup UI ships (<code>web#41</code>).
+      </p>
+    </main>
+  )
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -107,9 +107,16 @@ file_size_limit = "50MiB"
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "http://127.0.0.1:3000"
+site_url = "http://localhost:9001"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+additional_redirect_urls = [
+  "http://localhost:9001",
+  "http://localhost:9001/auth/test",
+  "http://127.0.0.1:9001",
+  "http://127.0.0.1:9001/auth/test",
+  "https://izzy-yum.com",
+  "https://izzy-yum.com/auth/callback",
+]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # If disabled, the refresh token will never expire.
@@ -244,9 +251,12 @@ max_frequency = "5s"
 # `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
 # `twitter`, `slack`, `spotify`, `workos`, `zoom`.
 [auth.external.apple]
-enabled = false
-client_id = ""
+enabled = true
+client_id = "com.izzyyum.app.web-signin"
 # DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+# SUPABASE_AUTH_EXTERNAL_APPLE_SECRET is the ES256 JWT produced by
+# scripts/generate-apple-client-secret.js; rotates every ~180 days.
+# See infrastructure/RUNBOOK_OAUTH_SETUP.md.
 secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
 # Overrides the default auth redirectUrl.
 redirect_uri = ""


### PR DESCRIPTION
## Summary
- Enables the Apple provider in Supabase local config (`[auth.external.apple]` in `supabase/config.toml`), pointing at the Services ID registered under #38 with an env-var-backed client secret.
- Adds `scripts/generate-apple-client-secret.js` — a zero-dependency Node script that mints the ES256 JWT Supabase requires as the Apple OAuth client secret. Apple caps that JWT's lifetime at ~6 months, so this script is the rotation tool (documented in [`infrastructure#<PR>`](https://github.com/izzy-yum/infrastructure/pull/1)).
- Adds a scratch `/auth/test` page for the end-to-end smoke test per the acceptance criteria. It will be deleted when #41 ships the real signup UI.
- Bumps `site_url` / `additional_redirect_urls` in `config.toml` to the real dev port (9001) and includes the production `izzy-yum.com/auth/callback`.
- Ignores `scripts/` in ESLint (standalone Node CJS, not Next.js code). Drops 6 pre-existing lint errors from `scripts/delete-user.js`.

Closes part of #38. Google OAuth is tracked separately in #50.

## Test plan
- [x] `npm run lint` — 60 pre-existing issues (down from 66 by ignoring `scripts/`), no new errors from this PR.
- [x] `npx tsc --noEmit` — clean.
- [ ] Local smoke test: `supabase stop && supabase start` with `SUPABASE_AUTH_EXTERNAL_APPLE_SECRET` exported → `npm run dev` → click "Continue with Apple" on `/auth/test` → complete Apple flow → page shows signed-in state with provider `apple`. **Running this after merge.**
- [ ] Cloud smoke test: deploy the `/auth/test` page via Vercel (manual, currently) → visit on `izzy-yum.com/auth/test` or directly on the Vercel preview → click Apple → same round-trip.

## Operational notes
- Apple client secret JWT was generated today; **expires 2026-10-17**. Rotation procedure and logbook live in the infra runbook PR.
- The `.p8` key + Team ID + Key ID live in `/Users/edwin/izzy_yum/apple-info.md` (outside any git repo) and should move to 1Password after today's session.